### PR TITLE
Styles for sections

### DIFF
--- a/docs/source/_includes/solutions.rst
+++ b/docs/source/_includes/solutions.rst
@@ -1,5 +1,6 @@
 .. toctree::
     :maxdepth: 3
+    :caption: Network Automation Suites
     :glob:
 
     solutions/*/index

--- a/docs/source/_themes/sphinx_rtd_theme/static/css/theme.css
+++ b/docs/source/_themes/sphinx_rtd_theme/static/css/theme.css
@@ -3477,7 +3477,7 @@ a.wy-text-neutral:hover {
   color: #595959 !important;
 }
 
-h1, h2, h3, h4, h5, h6, legend {
+h1, h2, h3, h4, h5, h6, .rst-content .toctree-wrapper p.caption, legend {
   margin-top: 0;
   font-weight: 400;
   font-family: Roboto, sans-serif;
@@ -3514,6 +3514,9 @@ h6 {
   font-size: 100%;
 }
 
+.rst-content .toctree-wrapper p.caption {
+  margin-bottom: 5px;
+}
 hr {
   display: block;
   height: 1px;
@@ -3994,16 +3997,18 @@ div[class^='highlight'] pre {
   padding: 0 16px;
 }
 
-.wy-menu-vertical header {
+.wy-menu-vertical header,
+.wy-menu-vertical p.caption {
   height: 32px;
   display: inline-block;
   line-height: 32px;
-  padding: 0 1.618em;
+  padding: 0 1.2em;
+  margin-bottom: 0;
   display: block;
   font-weight: bold;
   text-transform: uppercase;
   font-size: 80%;
-  color: #2980B9;
+  color: #f6ded7;
   white-space: nowrap;
 }
 .wy-menu-vertical ul {

--- a/docs/source/solutions/ipfabric/index.rst
+++ b/docs/source/solutions/ipfabric/index.rst
@@ -1,5 +1,5 @@
-IP Fabric Solution
-==================
+IP Fabric Automation Suite
+==========================
 
 .. rubric:: Contents:
 


### PR DESCRIPTION
1. To use sections, added `capture` style. This is how it will look when merged with st2docs.
Looking for advise for better color. 

2. while with that, added a section for "Solutions" for use on st2docs.

![pasted image at 2016_08_25 01_32](https://cloud.githubusercontent.com/assets/1294734/17965652/887e8554-6a72-11e6-8244-c16bb2af625c.png)
