### PR TITLE
fix-pilcrow

### DIFF
--- a/docs/source/_themes/sphinx_rtd_theme/static/css/theme.css
+++ b/docs/source/_themes/sphinx_rtd_theme/static/css/theme.css
@@ -4543,18 +4543,18 @@ nav.stickynav {
   margin: auto;
   display: block;
 }
-.rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink {
+.rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink, .rst-content p .headerlink {
   display: none;
   visibility: hidden;
   font-size: 14px;
 }
-.rst-content h1 .headerlink:after, .rst-content h2 .headerlink:after, .rst-content h3 .headerlink:after, .rst-content h4 .headerlink:after, .rst-content h5 .headerlink:after, .rst-content h6 .headerlink:after, .rst-content dl dt .headerlink:after {
+.rst-content h1 .headerlink:after, .rst-content h2 .headerlink:after, .rst-content h3 .headerlink:after, .rst-content h4 .headerlink:after, .rst-content h5 .headerlink:after, .rst-content h6 .headerlink:after, .rst-content dl dt .headerlink:after, .rst-content p .headerlink:after {
   visibility: visible;
   content: "";
   font-family: FontAwesome;
   display: inline-block;
 }
-.rst-content h1:hover .headerlink, .rst-content h2:hover .headerlink, .rst-content h3:hover .headerlink, .rst-content h4:hover .headerlink, .rst-content h5:hover .headerlink, .rst-content h6:hover .headerlink, .rst-content dl dt:hover .headerlink {
+.rst-content h1:hover .headerlink, .rst-content h2:hover .headerlink, .rst-content h3:hover .headerlink, .rst-content h4:hover .headerlink, .rst-content h5:hover .headerlink, .rst-content h6:hover .headerlink, .rst-content dl dt:hover .headerlink, .rst-content p:hover .headerlink {
   display: inline-block;
 }
 .rst-content .sidebar {


### PR DESCRIPTION
Fixes problem with pilcrow symbol displaying on caption header links, same fix as applied to st2docs.