### PR TITLE
name change cleanups

### DIFF
--- a/docs/source/solutions/ipfabric/index.rst
+++ b/docs/source/solutions/ipfabric/index.rst
@@ -1,4 +1,4 @@
-IP Fabric Automation Suite
+|ipf|
 ==========================
 
 .. rubric:: Contents:

--- a/docs/source/solutions/ipfabric/ipf_cli/basic_cli.rst
+++ b/docs/source/solutions/ipfabric/ipf_cli/basic_cli.rst
@@ -1,4 +1,4 @@
-IP Fabric Solution CLI
+|ipf| CLI
 ======================
 
 .. note::

--- a/docs/source/solutions/ipfabric/ipf_cli/index.rst
+++ b/docs/source/solutions/ipfabric/ipf_cli/index.rst
@@ -1,4 +1,4 @@
-IP Fabric Solution CLI Reference
+|ipf| CLI Reference
 ================================
 
 These CLI commands are supported. Click on a command for syntax, usage and examples.
@@ -8,5 +8,5 @@ These CLI commands are supported. Click on a command for syntax, usage and examp
 .. toctree::
     :maxdepth: 2
 
-    IP Fabric Solution CLI<basic_cli>
+    |ipf| CLI<basic_cli>
     Advanced CLI<advanced_cli>

--- a/docs/source/solutions/ipfabric/operation/index.rst
+++ b/docs/source/solutions/ipfabric/operation/index.rst
@@ -1,10 +1,10 @@
-How to use IP Fabric Solution
-=============================
+How to use the |ipf|
+=========================================
 
 This section explains how to operate the |ipf| to help you automate IP Fabric creation and scaling
 in your data center.
 
-.. rubric:: IP Fabric Solution for IP Fabric automation
+.. rubric:: IP Fabric Automation Suite for IP Fabric automation
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/solutions/ipfabric/overview.rst
+++ b/docs/source/solutions/ipfabric/overview.rst
@@ -1,5 +1,5 @@
-IP Fabric Solution
-==================
+|ipf|
+==========================
 
 
 Brocade Workflow Composer Overview
@@ -36,14 +36,14 @@ as well as OSPF) to exchange Layer 3 routing information.
 For more information about Brocade IP Fabrics, see the `Brocade Network OS IP Fabric Configuration
 Guide <http://www.brocade.com/content/html/en/configuration-guide/nos-701-ipfabrics/index.html>`_
 
-IP Fabric Automation Suite Overview
+|ipf| Overview
 -----------------------------------
 
 The |ipf| is an add-on package for |bwc| that provides services and pre-built automations for managing
 Brocade IP Fabrics. It can provision and validate Brocade IP Fabrics and BGP-EVPN with minimal effort.
 It can easily be customized as required.
 
-|ipf| helps users monitor and configure an IP Fabric. This solution can be used to:
+|ipf| helps users monitor and configure an IP Fabric. It can be used to:
 
 * Assign roles to the switches in the IP Fabric: *Spine* or *Leaf*, based on discovered connections.
 * Check current configurations on the switches, such as IP address, RBridge ID, links, LLDP, ASN, etc.
@@ -53,7 +53,7 @@ It can easily be customized as required.
 * Integrate with ZTP to automatically configure switches when they are added to the existing fabric.
 * Provision two-member leaf VCS clusters to support server dual-homing.
 
-This solution currently supports the External Border Gateway Protocol (eBGP) workflow to provision
+This automation suite currently supports the External Border Gateway Protocol (eBGP) workflow to provision
 an IP Fabric on VDX switches. This can be fully automated, or triggered manually via CLI or API.
 
 The eBGP-based workflow supports both IP numbered & unnumbered configurations.
@@ -65,4 +65,4 @@ The eBGP-based workflow supports both IP numbered & unnumbered configurations.
 
 What's Next?
 -------------------------------
-* Install and run Brocade Workflow Composer and IP Fabric solution - follow the :doc:`install` guide.
+* Install and run |bwc| and |ipf| - follow the :doc:`install` guide.


### PR DESCRIPTION
Fixes to use of "IP Fabric Solution" or "IP Fabric Suite" - should all be "IP Fabric Automation Suite", or even better, use |ipf|