### PR TITLE
reduced toc depth, capitalized heading

### DIFF
--- a/docs/source/_includes/solutions.rst
+++ b/docs/source/_includes/solutions.rst
@@ -1,5 +1,5 @@
 .. toctree::
-    :maxdepth: 3
+    :maxdepth: 2
     :caption: Network Automation Suites
     :glob:
 

--- a/docs/source/solutions/ipfabric/install.rst
+++ b/docs/source/solutions/ipfabric/install.rst
@@ -131,7 +131,7 @@ Install the |ipf|:
       # Check that it is running indeed
       systemctl bwc-topology status
 
-4. Smoke-check the installation
+4. Smoke-check the Installation
 -------------------------------
 
 Run some |ipf| CLI commands to see that everything is installed.


### PR DESCRIPTION
Changed TOC depth so we don't display as deep on main docs index page.

Small tidy up to heading capitalisation.