### PR TITLE
Add note re: build tools for VDX pack

### DIFF
--- a/docs/source/solutions/ipfabric/install.rst
+++ b/docs/source/solutions/ipfabric/install.rst
@@ -153,10 +153,11 @@ to try out our `VDX <https://github.com/StackStorm/st2contrib/tree/master/packs/
 
 First make sure you have the prerequisite libraries installed. On Ubuntu/Debian: ::
 
-      sudo apt-get install libxml2-dev libxslt1-dev
+      sudo apt-get install build-essential libxml2-dev libxslt1-dev
 
 On RHEL/CentOS: ::
 
+      sudo yum groupinstall "Development Tools"
       sudo yum install libxml2-dev libxslt1-dev
 
 Then install the pack: ::


### PR DESCRIPTION
The VDX pack pulls in various requirements via `pip`. That needs `gcc`, which is not on a minimal install system. This update tells users to install the build tools so that they can build the python packages that get pulled in