### PR TITLE
added ip fabric deprecation notice

### DIFF
--- a/docs/source/solutions/ipfabric/index.rst
+++ b/docs/source/solutions/ipfabric/index.rst
@@ -1,6 +1,13 @@
 |ipf|
 ==========================
 
+.. note::
+   This Automation Suite has been deprecated. New installations should use the Network Essentials and
+   DC Fabric Automation Suites. These are now available as Technology Preview. See `bwc-docs.brocade.com
+   <https://bwc-docs.brocade.com/latest/solutions/dcfabric/overview.html>`_ for more information on how
+   to install and use these new suites. Note that there is no direct upgrade path from IP Fabric Automation
+   Suite to DC Fabric Automation Suite
+
 .. rubric:: Contents:
 
 .. toctree::

--- a/docs/source/solutions/ipfabric/install.rst
+++ b/docs/source/solutions/ipfabric/install.rst
@@ -1,6 +1,13 @@
 Installation
 ============
 
+.. note::
+   This Automation Suite has been deprecated. New installations should use the Network Essentials and
+   DC Fabric Automation Suites. These are now available as Technology Preview. See `bwc-docs.brocade.com
+   <https://bwc-docs.brocade.com/latest/solutions/dcfabric/overview.html>`_ for more information on how
+   to install and use these new suites. Note that there is no direct upgrade path from IP Fabric Automation
+   Suite to DC Fabric Automation Suite
+
 To quickly install |bwc| with |ipf|, obtain a license key from `Brocade.com/bwc <https://www.brocade.com/bwc>`_, and
 run the commands below, replacing ``${BWC_LICENSE_KEY}`` with the key you received when registering for 
 evaluation or purchasing. These commands will install |bwc|, |ipf|, and configure all components to work

--- a/docs/source/solutions/ipfabric/overview.rst
+++ b/docs/source/solutions/ipfabric/overview.rst
@@ -5,6 +5,13 @@
 Brocade Workflow Composer Overview
 ----------------------------------
 
+.. note::
+   This Automation Suite has been deprecated. New installations should use the Network Essentials and
+   DC Fabric Automation Suites. These are now available as Technology Preview. See `bwc-docs.brocade.com
+   <https://bwc-docs.brocade.com/latest/solutions/dcfabric/overview.html>`_ for more information on how
+   to install and use these new suites. Note that there is no direct upgrade path from IP Fabric Automation
+   Suite to DC Fabric Automation Suite
+
 |bwc| is a network automation platform that automates the entire network life
 cycle and integrates with cross-domain workflows to improve business agility. Based on the
 StackStorm Open Source Project, Workflow Composer provides DevOps-inspired network automation


### PR DESCRIPTION
Add deprecation notice to IP Fabric docs, along with link to DC Fabric installation.

https://github.com/StackStorm/ipfabric-docs/pull/58 merged now, so the link to /latest/dcfabric works.