### PR TITLE
added support for canonical URL

### DIFF
--- a/docs/source/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout.html
@@ -18,6 +18,10 @@
   {% endblock %}
 
   <link rel="shortcut icon" href="{{ pathto('_static/favicon.ico', 1) }}?brocade"/>
+  {# CANONICAL URL #}
+  {% if theme_canonical_url %}
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+  {% endif %}
 
   {# CSS #}
   <!-- <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic|Inconsolata:400,700' rel='stylesheet' type='text/css'> -->

--- a/docs/source/_themes/sphinx_rtd_theme/layout_old.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout_old.html
@@ -125,6 +125,9 @@
     {%- if favicon %}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
     {%- endif %}
+    {%- if theme_canonical_url %}
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+    {%- endif %}
     {%- endif %}
 {%- block linktags %}
     {%- if hasdoc('about') %}

--- a/docs/source/_themes/sphinx_rtd_theme/theme.conf
+++ b/docs/source/_themes/sphinx_rtd_theme/theme.conf
@@ -10,3 +10,4 @@ sticky_navigation = False
 # Specify a base_url used to generate sitemap.xml links. If not specified, then
 # no sitemap will be built.
 base_url =
+canonical_url =

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -11,7 +11,7 @@ project = u'bwc-docs'
 copyright = u'2016, Brocade Communications Inc'
 author = u'Brocade Communications Inc'
 
-base_url = u'http://bwc-docs.brocade.com/'
+base_url = u'https://bwc-docs.brocade.com/'
 htmlhelp_basename = 'bwc-doc'
 
 man_pages = [


### PR DESCRIPTION
Similar change to https://github.com/StackStorm/st2docs/pull/443, to add support for canonical URLs, to steer Google towards indexing current docs, not old version.

If it's OK, we can back port to 2.0, 2.1 & 2.2. No need to back port to 1.x for BWC docs (phew!).