### PR TITLE
V2.1 Canonical URL

### DIFF
--- a/docs/source/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout.html
@@ -18,6 +18,10 @@
   {% endblock %}
 
   <link rel="shortcut icon" href="{{ pathto('_static/favicon.ico', 1) }}?brocade"/>
+  {# CANONICAL URL #}
+  {% if theme_canonical_url %}
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+  {% endif %}
 
   {# CSS #}
   <!-- <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic|Inconsolata:400,700' rel='stylesheet' type='text/css'> -->

--- a/docs/source/_themes/sphinx_rtd_theme/layout_old.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout_old.html
@@ -125,6 +125,9 @@
     {%- if favicon %}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
     {%- endif %}
+    {%- if theme_canonical_url %}
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+    {%- endif %}
     {%- endif %}
 {%- block linktags %}
     {%- if hasdoc('about') %}

--- a/docs/source/_themes/sphinx_rtd_theme/theme.conf
+++ b/docs/source/_themes/sphinx_rtd_theme/theme.conf
@@ -10,3 +10,4 @@ sticky_navigation = False
 # Specify a base_url used to generate sitemap.xml links. If not specified, then
 # no sitemap will be built.
 base_url =
+canonical_url =

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -33,4 +33,4 @@ texinfo_documents = [
 github_repo = 'StackStorm/st2docs'
 github_version = 'master'
 
-theme_base_url = u'http://bwc-docs.brocade.com/'
+theme_base_url = u'https://bwc-docs.brocade.com/'

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -11,8 +11,8 @@ project = u'ipfabric-docs'
 copyright = u'2016, Brocade Communications Inc'
 author = u'Brocade Communications Inc'
 
-base_url = u'http://bwc-docs.brocade.com/'
-htmlhelp_basename = 'ipfabric-doc'
+base_url = u'https://bwc-docs.brocade.com/'
+htmlhelp_basename = 'bwc-doc'
 
 man_pages = [
     ('index', 'ipfabric-docs', u'IPFabric Documentation',


### PR DESCRIPTION
Steer Google towards newer docs. Partly addresses https://github.com/StackStorm/st2docs/issues/403