### PR TITLE
Add github_user to info.py

### DIFF
--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -30,7 +30,8 @@ texinfo_documents = [
 
 # TODO(dzimine): find a way for links to work for both bwc and st2docs.
 # For now, optimize for where most docs written.
-github_repo = 'StackStorm/st2docs'
+github_user = 'StackStorm'
+github_repo = 'st2docs'
 github_version = 'master'
 
 theme_base_url = u'https://bwc-docs.brocade.com/'


### PR DESCRIPTION
Fixes double-slash in "Edit on Github" link. Pre-requisite for upcoming changes to allow over-riding GitHub URL on per-page basis