### PR TITLE
Begin migrating Brocade -> Extreme

### DIFF
--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -1,30 +1,30 @@
 # -*- coding: utf-8 -*-
 #
 # This file contains values that differ between open-source
-# to commercial (BWC) documentation. Everything that might
+# to commercial (EWC) documentation. Everything that might
 # change from one version to another in conf.py should be
 # placed here, otherwise you WILL break the build.
 
 master_doc = 'index'
 
 project = u'bwc-docs'
-copyright = u'2016, Brocade Communications Inc'
-author = u'Brocade Communications Inc'
+copyright = u'2018, Extreme Networks, Inc'
+author = u'Extreme Networks, Inc'
 
 base_url = u'https://bwc-docs.brocade.com/'
 htmlhelp_basename = 'bwc-doc'
 
 man_pages = [
-    ('index', 'bwc-docs', u'BWC Documentation',
-     [u'Brocade'], 1)
+    ('index', 'bwc-docs', u'EWC Documentation',
+     [u'Extreme Networks'], 1)
 ]
 latex_documents = [
     (master_doc, 'bwc-docs.tex', u'bwc-docs Documentation',
-     u'Brocade Communications Inc', 'manual'),
+     u'Extreme Networks, Inc', 'manual'),
 ]
 texinfo_documents = [
-    (master_doc, 'bwc-docs', u'BWC Documentation',
-     u'Brocade', 'bwc-docs', 'One line description of project.',
+    (master_doc, 'bwc-docs', u'EWC Documentation',
+     u'Extreme Networks', 'bwc-docs', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/source/solutions/__tech_preview.rst
+++ b/docs/source/solutions/__tech_preview.rst
@@ -3,7 +3,7 @@
     All Automation Suites are currently in "Technology Preview" phase. We are releasing them
     to gain additional feedback, but do not recommend running them in production. We encourage
     people to try them out in non-production scenarios. They have had basic testing, but are
-    not supported by Brocade TAC.
+    not supported by Extreme Networks TAC.
 
     Please join our `StackStorm community <http://www.stackstorm.com/community/>`__ to talk to fellow
     users and report issues, or request enhancements.

--- a/docs/source/solutions/dcfabric/dcf_cli/basic_cli.rst
+++ b/docs/source/solutions/dcfabric/dcf_cli/basic_cli.rst
@@ -66,7 +66,7 @@ Refer to :command:`bwc dcf inventory/fabric <command> --help` for more informati
 Examples
 ~~~~~~~~
 
-Use the ``bwc --help`` command to display Brocade Workflow Composer commands and their functions.
+Use the ``bwc --help`` command to display Extreme Workflow Composer commands and their functions.
 
 
 .. code-block:: guess

--- a/docs/source/solutions/dcfabric/install.rst
+++ b/docs/source/solutions/dcfabric/install.rst
@@ -2,7 +2,7 @@ Installation
 ============
 
 .. warning::
-    If you had previously installed the BWC 2.0 IP Fabric Automation Suite,
+    If you had previously installed the EWC 2.0 IP Fabric Automation Suite,
     we recommend installing the DC Fabric Automation Suite on a new Virtual Machine.
 
 .. contents::
@@ -46,24 +46,24 @@ Simple Installation
 -------------------
 
 To quickly install |bwc| with DC Fabric Automation Suite, obtain a license key from
-`brocade.com/bwc <https://www.brocade.com/bwc>`_, and run the commands below, replacing
-``${BWC_LICENSE_KEY}`` with the key you received when registering for evaluation or
+`www.extremenetworks.com/product/workflow-composer/ <https://www.extremenetworks.com/product/workflow-composer/>`_, and run the commands below, replacing
+``${EWC_LICENSE_KEY}`` with the key you received when registering for evaluation or
 purchasing. These commands will install |bwc|, Network Essentials, DC Fabric Automation Suite,
 and configure all components to work together on a single host:
 
 .. code-block:: bash
 
   curl -SsL -O https://brocade.com/bwc/install/install.sh && chmod +x install.sh
-  ./install.sh --user=st2admin --password=Ch@ngeMe --suite=dcfabric-suite --license=${BWC_LICENSE_KEY}
+  ./install.sh --user=st2admin --password=Ch@ngeMe --suite=dcfabric-suite --license=${EWC_LICENSE_KEY}
 
 If you already have |bwc| installed, and need to add DC Fabric on top of an existing |bwc| installation,
-run the following commands, replacing ``${BWC_LICENSE_KEY}`` with the key you received when 
+run the following commands, replacing ``${EWC_LICENSE_KEY}`` with the key you received when 
 registering for evaluation or purchasing:
 
 .. code-block:: bash
 
   curl -SsL -O https://brocade.com/bwc/install/install-suite.sh && chmod +x install-suite.sh
-  ./install-suite.sh --user=st2admin --password=Ch@ngeMe --suite=dcfabric-suite --license=${BWC_LICENSE_KEY}
+  ./install-suite.sh --user=st2admin --password=Ch@ngeMe --suite=dcfabric-suite --license=${EWC_LICENSE_KEY}
 
 .. note::
 
@@ -80,7 +80,7 @@ Components
 ~~~~~~~~~~
 
 The DC Fabric Automation Suite installs on top of |bwc|. It adds an inventory & topology service, and
-DC Fabric automation packs containing actions and workflows to simplify Brocade Data Center Fabric management.
+DC Fabric automation packs containing actions and workflows to simplify Data Center Fabric management.
 It also includes the ``bwc dcf`` CLI, and Zero Touch Provisioning scripts for integration with :doc:`ZTP <ztp_reference>`.
 This suite uses components of the :doc:`../essentials/overview` suite. If the Network Essentials suite is not
 currently installed it will be automatically installed during DC Fabric suite installation.
@@ -118,7 +118,7 @@ Install the DC Fabric suite:
 
 * Generate an API key to connect the topology service to st2 API: ::
 
-    st2 apikey create -k -m '{"used_for": "BWC topology service"}'
+    st2 apikey create -k -m '{"used_for": "EWC topology service"}'
 
 * Edit the configuration file ``/etc/brocade/bwc/bwc-topology-service.conf``,
   set ``st2_api_key`` value to the st2 API key, and change the default DB
@@ -220,6 +220,6 @@ If you have previously installed DC Fabric Automation Suite and want to upgrade 
 
 .. rubric:: What's Next?
 
-* New to |BWC|? Go to fundamentals - start with :doc:`/start`.
+* New to |bwc|? Go to fundamentals - start with :doc:`/start`.
 * Understand the DC Fabric operations - go over :doc:`./operation/overview`.
 * Understand the DC Fabric CLI - read the :doc:`./dcf_cli/basic_cli`.

--- a/docs/source/solutions/dcfabric/operation/index.rst
+++ b/docs/source/solutions/dcfabric/operation/index.rst
@@ -2,7 +2,7 @@ How to use the DC Fabric Automation Suite
 =========================================
 
 This section explains how to use the DC Fabric Automation Suite to help you 
-manage Brocade VCS and IP Fabrics in your data center.
+manage Extreme Networks VCS and IP Fabrics in your data center.
 
 .. rubric:: DC Fabric Automation Suite
 

--- a/docs/source/solutions/dcfabric/operation/overview.rst
+++ b/docs/source/solutions/dcfabric/operation/overview.rst
@@ -5,15 +5,15 @@ Introduction
 ------------
 
 This document provides an overview of how to use the DC Fabric suite to automate provisioning and 
-maintenance of a Brocade IP or VCS Fabric. The DC Fabric suite can automatically configure
+maintenance of an IP or VCS Fabric. The DC Fabric suite can automatically configure
 interfaces, BGP peerings and related settings. This ensures consistent configuration
 across the fabric, with minimal effort.
 
 .. note::
     This document covers the operation of the |bwc| DC Fabric suite. For more information
-    about Brocade IP Fabrics in general, see the `Brocade Network OS IP Fabric
+    about IP Fabrics in general, see the `Network OS IP Fabric
     Configuration Guide <http://www.brocade.com/content/html/en/configuration-guide/nos-701-ipfabrics/index.html>`_
-    and the `Brocade IP Fabric Validated Design <http://www.brocade.com/content/html/en/brocade-validated-design/brocade-ip-fabric-bvd/GUID-35138986-3BBA-4BD0-94B4-AFABB2E01D77-homepage.html>`_ 
+    and the `IP Fabric Validated Design <http://www.brocade.com/content/html/en/brocade-validated-design/brocade-ip-fabric-bvd/GUID-35138986-3BBA-4BD0-94B4-AFABB2E01D77-homepage.html>`_ 
 
 The DC Fabric suite supports easy integration with Zero-Touch Provisioning (ZTP). It can also be used 
 without ZTP, but initial switch setup and registration will be a manual process.
@@ -25,7 +25,7 @@ as ASN range, IP address ranges, etc. To see these parameters, and change them, 
 .. figure:: ../../../_static/images/solutions/dcfabric/bwc_components.jpg
     :align: center
 
-    **Components of Brocade Flow Composer**
+    **Components of Extreme Flow Composer**
 
 .. note::
     The VCS ID for spine and leaves should be different in both the ZTP-enabled configuration and
@@ -51,7 +51,7 @@ Setting up IP Fabric with EVPN
    This example uses the default fabric. First switch added must be a spine, and roles
    for the rest of the switches are automatically discovered by the DC Fabric automation suite. 
    
-   Using BWC CLI you can register the switches as below:
+   Using ``bwc`` CLI you can register the switches as below:
 
    .. code-block:: bash
 

--- a/docs/source/solutions/dcfabric/operation/setup_ipfabric.rst
+++ b/docs/source/solutions/dcfabric/operation/setup_ipfabric.rst
@@ -1,30 +1,31 @@
 Setting Up An IP Fabric
 =======================
 
-This document provides an overview of how to use the Brocade Workflow Composer DC Fabric Automation Suite to automate the provisioning and the maintenance of a Brocade IP Fabric. The DC Fabric Automation Suite can automatically configure
-interfaces, BGP peering and related settings. This ensures consistent configuration
-across the IP fabric, with minimal effort.
+This document provides an overview of how to use the Extreme Workflow Composer DC Fabric Automation
+Suite to automate the provisioning and the maintenance of a IP Fabric. The DC Fabric Automation
+Suite can automatically configure interfaces, BGP peering and related settings. This ensures
+consistent configuration across the IP fabric, with minimal effort.
 
 .. note::
     This document covers the operation of the |bwc| DC Fabric Automation Suite. For more information
-    about Brocade IP Fabrics in general, refer to the `Brocade Network OS IP Fabric
+    about IP Fabrics in general, refer to the `Network OS IP Fabric
     Configuration Guide <http://www.brocade.com/content/html/en/configuration-guide/nos-701-ipfabrics/index.html>`_
-    and the `Brocade IP Fabric Validated Design <http://www.brocade.com/content/html/en/brocade-validated-design/brocade-ip-fabric-bvd/GUID-35138986-3BBA-4BD0-94B4-AFABB2E01D77-homepage.html>`_ 
+    and the `IP Fabric Validated Design <http://www.brocade.com/content/html/en/brocade-validated-design/brocade-ip-fabric-bvd/GUID-35138986-3BBA-4BD0-94B4-AFABB2E01D77-homepage.html>`_ 
 
-The BWC DC Fabric automation suite supports easy integration with Zero-Touch Provisioning (ZTP). It can also be used 
+The EWC DC Fabric automation suite supports easy integration with Zero-Touch Provisioning (ZTP). It can also be used 
 without ZTP, however, initial switch setup and registration will be a manual process.
 
-The BWC DC Fabric automation suite's default configuration comes with a set of predefined configuration parameters such 
+The EWC DC Fabric automation suite's default configuration comes with a set of predefined configuration parameters such 
 as ASN range, and IP address ranges which can be used to create an IP fabric. The values of these predefined configuration parameters are fixed and cannot be changed. To see the list of these predefined parameters, refer to the
 :ref:`IP Fabric configuration parameters<ip_fabric_parameters>` documentation.
 
 .. figure:: ../../../_static/images/solutions/dcfabric/bwc_components.jpg
     :align: center
 
-    **Components of Brocade Workflow Composer**
+    **Components of Extreme Workflow Composer**
 
-The illustration shows the components of the Brocade Workflow Composer and the switch spines and leaves connectivity. This will be
-the example setup for showing how to initially provision an IP Fabric using BWC.
+The illustration shows the components of the |bwc| and the switch spines and leaves connectivity. This will be
+the example setup for showing how to initially provision an IP Fabric using EWC.
 
 Once your IP Fabric is provisioned, check out the :doc:`Using IP Fabric<using_ipfabric>` documentation
 for Day-N service provisioning workflows.
@@ -40,16 +41,16 @@ Initial Fabric Provisioning
 Configuring an IP Fabric with ZTP enabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The BWC DC Fabric automation suite can automatically provision a Brocade VDX switch and create an IP Fabric on the switch
+The DC Fabric automation suite can automatically provision a VDX switch and create an IP Fabric on the switch
 if the switch has ZTP enabled and if no management IP address has been assigned to the switch.
 
 Zero Touch Provisioning (ZTP) can be used to bring up a switch with new firmware and a preset configuration automatically. The switch does not need to be configured via the console. ZTP uses a DHCP-based process known as DHCP Automatic Deployment (DAD) to handle basic configuration such as assigning a VCS ID, VCS mode, an RBridge ID, and downloading firmware.
 
-As part of the ZTP process, the switch can execute a local script. This stage is used to register the switch with Brocade Workflow Composer and run the BGP workflow if desired.
+As part of the ZTP process, the switch can execute a local script. This stage is used to register the switch with |bwc| and run the BGP workflow if desired.
 
 .. note::
     For detailed information about ZTP, refer to the :doc:`ZTP reference <../ztp_reference>`
-    and the `Brocade Network OS Administration Guide <http://www.brocade.com/content/html/en/administration-guide/nos-701-adminguide/GUID-B70DA4FE-6819-45A9-9E07-65785D7DB402.html>`_.
+    and the `Network OS Administration Guide <http://www.brocade.com/content/html/en/administration-guide/nos-701-adminguide/GUID-B70DA4FE-6819-45A9-9E07-65785D7DB402.html>`_.
 
 .. warning::
     The first switch that is powered on and executes the ZTP process must be a spine switch.
@@ -63,7 +64,7 @@ If the switch has ZTP enabled, complete the following steps:
 
 .. note::
     Make sure switches have not been powered on. Connect the switches in a leaf-spine topology as shown in the illustration.
-    BWC DC Fabric automation suite assigns management IP addresses to the switches, registers the switches in its 
+    DC Fabric automation suite assigns management IP addresses to the switches, registers the switches in its 
     database, and creates an IP Fabric.
 
 .. code:: shell
@@ -148,17 +149,17 @@ If the switch has ZTP enabled, complete the following steps:
 Configuring an IP Fabric manually or without ZTP enabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the Brocade VDX switch does not have ZTP enabled or if you want to configure an IP Fabric
+If the VDX switch does not have ZTP enabled or if you want to configure an IP Fabric
 manually, complete the following steps:
 
-    1.  Register the switch in the Brocade Workflow Composer database   
+    1.  Register the switch in the |bwc| database   
     2.  Verify that the switch is registered.    
     3.  Repeat Steps 1 and 2 for each switch that will be added to the IP Fabric. 
     4.  Execute the BGP workflow
     5.  Review and verify the IP Fabric configuration using the the bwc dcf show config bgp command 
 
 .. note::
-    To use the BWC DC Fabric automation suite to configure an IP Fabric without ZTP enabled, your environment must meet
+    To use the DC Fabric automation suite to configure an IP Fabric without ZTP enabled, your environment must meet
     these prerequisites: 
 
      * The switches are physically connected in a leaf-spine topology.
@@ -172,7 +173,7 @@ manually, complete the following steps:
     has been added, the order of adding more switches will not matter as they will be automatically identified as Spine or Leaf      
     switches using LLDP.
 
-Use the BWC DC Fabric automation suite CLI to configure an IP Fabric by completing the following steps:
+Use the DC Fabric automation suite CLI to configure an IP Fabric by completing the following steps:
 
 1. Register the switches in the |bwc| database by entering the ``bwc dcf inventory
    register`` command:
@@ -480,7 +481,14 @@ switch configuration, use following commands:
 IP Fabric configuration parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This BWC DC IP Fabric automation suite has a default set of configuration parameters defined for an IP Fabric. The default set of configuration paramter values are fixed and cannot be changed by users. Some of the parameters have been changed in v1.1 of the automation suite based on `Brocade IP Fabric Validated Design <http://www.brocade.com/content/html/en/brocade-validated-design/brocade-ip-fabric-bvd/GUID-35138986-3BBA-4BD0-94B4-AFABB2E01D77-homepage.html>`_ recommendations. In addition some new parameters have also been added in v1.1.  You can display the values of the parameters using the ``bwc dcf fabric config show`` CLI command.  The table below shows the comparison for both DC IP Fabirc automation suite v1.0 and v1.1 values with the display showing only one version.
+This DC IP Fabric automation suite has a default set of configuration parameters defined for an
+IP Fabric. The default set of configuration paramter values are fixed and cannot be changed by
+users. Some of the parameters have been changed in v1.1 of the automation suite based on
+`IP Fabric Validated Design <http://www.brocade.com/content/html/en/brocade-validated-design/brocade-ip-fabric-bvd/GUID-35138986-3BBA-4BD0-94B4-AFABB2E01D77-homepage.html>`_
+recommendations. In addition some new parameters have also been added in v1.1. You can display the
+values of the parameters using the ``bwc dcf fabric config show`` CLI command.  The table below
+shows the comparison for both DC IP Fabric automation suite v1.0 and v1.1 values with the display
+showing only one version.
 
 .. code:: shell
     
@@ -575,7 +583,7 @@ command as explained in next section:
 +------------------------+-------------------------------------------------------------------+
 
 The required parameters must be added to the user-defined/custom configuration. The other
-parameters are not optional.If you do not add optional parameters, Brocade Workflow Composer
+parameters are not optional. If you do not add optional parameters, |bwc|
 will use the values from the default configuration.
 
 .. note::

--- a/docs/source/solutions/dcfabric/overview.rst
+++ b/docs/source/solutions/dcfabric/overview.rst
@@ -1,22 +1,27 @@
 DC Fabric Automation Suite
 ==========================
 
-Brocade Data Center products enable customers to build cloud optimized network and network virtualization architectures using VDX and SLX products.  Brocade supports multiple network architectures for data center fabric depending on the customer application and scale requirements.  Two main fabric architectures are “VCS Fabric” and “IP Fabric”.  VCS Fabric is a TRILL-based Layer-2 fabric, while IP Fabric is a BGP-based Layer-3 fabric, which can be used with or without BGP-EVPN.  The section below describes most common topologies for these two network architectures.
+Extreme Networks Data Center products enable customers to build cloud optimized network and network
+virtualization architectures using VDX and SLX products. Extrme supports multiple network
+architectures for data center fabric depending on the customer application and scale requirements.
+Two main fabric architectures are “VCS Fabric” and “IP Fabric”.  VCS Fabric is a TRILL-based
+Layer-2 fabric, while IP Fabric is a BGP-based Layer-3 fabric, which can be used with or without
+BGP-EVPN. The section below describes most common topologies for these two network architectures.
 
 The DC Fabric Automation Suite can be used to manage both fabric architectures. Workflows include
 initial fabric configuration, tenant provisioning, edge port configuration, etc. Some workflows
 are specific to the fabric architecture and the topology, while others work for all architectures.
 
-Brocade VCS Fabric
-------------------
+VCS Fabric
+----------
 
-Brocade VCS Fabric Technology can be used to deploy a data center fabric in different topologies.
-This section summarizes the most common deployment models for Brocade VCS fabric. For more details
-on the design considerations for each of the deployment models, refer to the `Brocade Data Center
+VCS Fabric Technology can be used to deploy a data center fabric in different topologies.
+This section summarizes the most common deployment models for VCS Fabric. For more details
+on the design considerations for each of the deployment models, refer to the `Data Center
 Architecture Solution Design Guide
 <http://www.brocade.com/content/html/en/solution-design-guide/brocade-dc-fabric-architectures-sdg/index.html>`_
 
-The diagram below shows a data center site built using a leaf-spine topology deployed using Brocade
+The diagram below shows a data center site built using a leaf-spine topology deployed using
 VCS Fabric technology. In this topology, the spines are connected to the data center core/WAN edge
 devices directly. The spine PIN in this topology is sometimes referred to as the "border spine"
 because it performs both the spine function of east-west traffic switches and the border function
@@ -25,7 +30,7 @@ of providing an interface to the data center core/WAN edge.
 .. figure:: ../../_static/images/solutions/dcfabric/vcs_fabric_l3_spine.png
       :align: center
 
-      **Brocade VCS Fabric with Layer 3 Boundary at the Spine**
+      **VCS Fabric with Layer 3 Boundary at the Spine**
 
 The Layer 3 boundary for all networking endpoints is shown to be in the spine. The spine devices
 participate in active-active gateway redundancy using VRRP-E or Fabric Virtual Gateway. 
@@ -38,7 +43,7 @@ core/WAN edge devices. Multitenancy can be achieved at Layer 3 using Virtual Rou
 .. figure:: ../../_static/images/solutions/dcfabric/vcs_fabric_separate_l3.png
       :align: center
 
-      **Brocade VCS Fabric with Layer 3 Boundary Outside the Fabric**
+      **VCS Fabric with Layer 3 Boundary Outside the Fabric**
 
 The Layer 3 boundary for all networking endpoints can also be at the border leaf switches, as shown
 below. Here the border leafs are shown as part of the VCS fabric. However, they can be a separate VCS
@@ -48,7 +53,7 @@ dual-side vLAG:
 .. figure:: ../../_static/images/solutions/dcfabric/vcs_fabric_l3_border_leaf.png
       :align: center
 
-      **Brocade VCS Fabric with Layer 3 Boundary at the Border Leaf**
+      **VCS Fabric with Layer 3 Boundary at the Border Leaf**
 
 Workflows for VCS fabric include:
 
@@ -60,15 +65,15 @@ Workflows for VCS fabric include:
 See the :doc:`operation/overview` documentation for details about these workflows.
 
 
-Brocade IP Fabric
------------------
+IP Fabric
+---------
 
-Brocade IP fabric provides a Layer 3 Clos deployment architecture for data center sites. With Brocade
+IP fabric provides a Layer 3 Clos deployment architecture for data center sites. With
 IP fabric, all links in the Clos topology are Layer 3 links. A data center PoD built with IP fabrics
 supports dual-homing of network endpoints using multiswitch port channel interfaces formed between a
-pair of Brocade VDX switches participating in a vLAG. This pair of leaf switches is called a vLAG
-pair. For more details on the design considerations for Brocade IP fabric, refer to the
-`Brocade Data Center Architecture Solution Design Guide 
+pair of VDX switches participating in a vLAG. This pair of leaf switches is called a vLAG
+pair. For more details on the design considerations for IP fabric, refer to the
+`Data Center Architecture Solution Design Guide 
 <http://www.brocade.com/content/html/en/solution-design-guide/brocade-dc-fabric-architectures-sdg/index.html>`_
 
 .. figure:: ../../_static/images/solutions/dcfabric/ip_fabric_dual_home.png
@@ -76,21 +81,21 @@ pair. For more details on the design considerations for Brocade IP fabric, refer
 
       **An IP Fabric Data Center PoD Built with Leaf-Spine Topology and a vLAG Pair for Dual-Homed Network Endpoint**
 
-The Layer 3 boundary in a Brocade IP fabric is always at the leaves. In cases of multi-homed network
+The Layer 3 boundary in an IP fabric is always at the leaves. In cases of multi-homed network
 endpoints, gateway redundancy using VRRP-E is used to provide active-active forwarding on the vLAG pair.
 
-Brocade IP Fabrics can also be deployed with BGP-EVPN. With Brocade BGP-EVPN network virtualization,
-network virtualization is achieved through creation of a VXLAN-based overlay network. Brocade BGP-EVPN
+IP Fabrics can also be deployed with BGP-EVPN. With BGP-EVPN network virtualization,
+network virtualization is achieved through creation of a VXLAN-based overlay network. BGP-EVPN
 network virtualization leverages BGP-EVPN to provide a control plane for the virtual overlay network.
 BGP-EVPN enables control-plane learning for end hosts behind remote VXLAN tunnel endpoints (VTEPs).
 This learning includes reachability for Layer 2 MAC addresses and Layer 3 host routes.
 
 With BGP-EVPN deployed in a data center site, the leaf switches participate in the BGP-EVPN control- and
 data-plane operations. These are shown as BGP-EVPN Instance (EVI) below. The spine switches
-participate only in the BGP-EVPN control plane. For more details on the design considerations for Brocade
-IP fabric, refer to the `Brocade Data Center Architectures for Network Virtualization Solution Design Guide
+participate only in the BGP-EVPN control plane. For more details on the design considerations for
+IP fabric, refer to the `Data Center Architectures for Network Virtualization Solution Design Guide
 <http://www.brocade.com/content/html/en/solution-design-guide/brocade-dc-network-virtualization-sdg/index.html>`_
-and `Network Virtualization in IP Fabric with BGP EVPN Brocade Validated Design
+and `Network Virtualization in IP Fabric with BGP EVPN Validated Design
 <http://www.brocade.com/content/html/en/brocade-validated-design/brocade-ip-fabric-bvd/GUID-35138986-3BBA-4BD0-94B4-AFABB2E01D77-homepage.html>`_
 
 .. figure:: ../../_static/images/solutions/dcfabric/ip_fabric_bgp_evpn.png
@@ -124,8 +129,8 @@ The DC Fabric Automation Suite supports the following devices:
 
 In addition to above device, 1.1 includes support for the following SLX devices:
 
-* IP Fabric (no EVPN) - Brocade SLX 9850 running SLX-OS SLX-OS_16r.1.1, SLX-OS_17r.1.00 and later
-* IP Fabric (no EVPN) - Brocade SLX 9540 running OS SLX-OS_17r.1.00 and later
+* IP Fabric (no EVPN) - SLX 9850 running SLX-OS SLX-OS_16r.1.1, SLX-OS_17r.1.00 and later
+* IP Fabric (no EVPN) - SLX 9540 running OS SLX-OS_17r.1.00 and later
 
 What's Next?
 -------------------------------

--- a/docs/source/solutions/dcfabric/workflows.rst
+++ b/docs/source/solutions/dcfabric/workflows.rst
@@ -213,7 +213,10 @@ Error Messages
 Manage VCS Fabric Tenants and Edge Ports
 ----------------------------------------
 
-Brocade VCS fabric automatically forms with minimal Day-0 configurations.  This section includes the actions and workflows to automate Day-N services such as provisioning of tenants, gateways and edge ports to enable the deployment of endpoints such as Servers, Firewalls and Load Balancers etc. on a VCS fabric.  Refer to :doc:`Brocade VCS Fabric<overview>` for various deployment models.
+VCS fabric automatically forms with minimal Day-0 configurations.  This section includes the
+actions and workflows to automate Day-N services such as provisioning of tenants, gateways and edge
+ports to enable the deployment of endpoints such as Servers, Firewalls and Load Balancers etc. on a
+VCS fabric.  Refer to :doc:`VCS Fabric<overview>` for various deployment models.
 
 .. include:: /_includes/solutions/dcfabric/add_multihomed_endpoint.rst
 

--- a/docs/source/solutions/dcfabric/ztp_reference.rst
+++ b/docs/source/solutions/dcfabric/ztp_reference.rst
@@ -1,5 +1,5 @@
-Using ZTP with Brocade Workflow Composer
-========================================
+Using ZTP with |bwc|
+====================
 
 Zero Touch Provisioning (ZTP) can be used to bring up a switch with new firmware and a
 preset configuration automatically. The switch does not need to be configured via the
@@ -8,7 +8,7 @@ handle basic configuration such as assigning a VCS ID, VCS mode, an RBridge ID, 
 downloading firmware. 
 
 For more information, refer to the `Using DHCP Automatic Deployment <http://www.brocade.com/content/html/en/administration-guide/nos-701-adminguide/GUID-B70DA4FE-6819-45A9-9E07-65785D7DB402.html>`_
-section of the `Brocade Network OS Administration Guide <http://www.brocade.com/content/html/en/administration-guide/nos-701-adminguide/GUID-E7A18ADA-3D26-475A-BE56-13088EC74EFF-homepage.html>`_.
+section of the `Network OS Administration Guide <http://www.brocade.com/content/html/en/administration-guide/nos-701-adminguide/GUID-E7A18ADA-3D26-475A-BE56-13088EC74EFF-homepage.html>`_.
 
 As part of the ZTP process, the switch can execute a local script. This stage is used to
 register the switch with |bwc| and run the BGP workflow.
@@ -429,7 +429,7 @@ Use the following guidelines when running ZTP and DAD:
 
     When running ZTP or DAD, if you use dhcp autodeployment enable, if anything is wrong
     in the setup or configurations, DC Fabric Automation suite will display the incorrect configuration.
-    While running ZTP, Brocade recommends that you run this command and see if everything is set
+    While running ZTP, Extreme recommends that you run this command and see if everything is set
     up correctly. If everything is correct, you will be prompted to reboot the switch. At
     this point you can enter “no” if you want to run ZTP and then use the write erase command.
     This step is helpful because the ZTP and DAD process itself is lengthy.
@@ -446,7 +446,7 @@ To verify whether the ZTP and DAD process ran correctly, complete the following 
 2. Run the ``show dad status`` command to make sure the DAD and ZTP process ran. Look for the
    ``DAD 1314`` code. If there any other error codes, refer to the `Using DHCP Automatic Deployment
    <http://www.brocade.com/content/html/en/administration-guide/nos-701-adminguide/GUID-B70DA4FE-6819-45A9-9E07-65785D7DB402.html>`_
-   section of the `Brocade Network OS Administration Guide <http://www.brocade.com/content/html/en/administration-guide/nos-701-adminguide/GUID-E7A18ADA-3D26-475A-BE56-13088EC74EFF-homepage.html>`_
+   section of the `Network OS Administration Guide <http://www.brocade.com/content/html/en/administration-guide/nos-701-adminguide/GUID-E7A18ADA-3D26-475A-BE56-13088EC74EFF-homepage.html>`_
    for more information about additional DAD codes.
 
 3. Check the |bwc| server to see if the switch is registered and the BGP workflow completed

--- a/docs/source/solutions/essentials/overview.rst
+++ b/docs/source/solutions/essentials/overview.rst
@@ -4,7 +4,11 @@ Network Essentials
 Overview
 --------
 
-Network Essentials includes key foundational actions and workflows to automate Brocade network devices.  This release includes automation building blocks for common networking tasks such as Edge Ports configuration and validation, Access Control List management.  These basic building blocks are used by other Brocade Automation Suites.  Customers can also use these Actions to create their own custom workflows for their specific automation needs.
+Network Essentials includes key foundational actions and workflows to automate Extreme network
+devices. This release includes automation building blocks for common networking tasks such as Edge
+Ports configuration and validation, Access Control List management. These basic building blocks are
+used by other Automation Suites. Customers can also use these Actions to create their own custom
+workflows for their specific automation needs.
 
 Included Actions
 ----------------
@@ -42,11 +46,11 @@ Supported Devices
 
 The Network Essentials Suite supports the following devices:
 
-* Brocade VDX 6740, 6940, 8770 running Network OS 6.0.2c, 7.0.1b, 7.1.0 and later
-* Brocade SLX 9850 running SLX-OS SLX-OS_16r.1.1, SLX-OS_17r.1.00 and later
-*	Brocade SLX 9540 running OS SLX-OS_17r.1.00 and later 
-*	Brocade SLX 9240 running OS SLX-OS_17s.1.00 and later
-*	Brocade SLX 9140 running OS SLX-OS_17s.1.00 and later
+* VDX 6740, 6940, 8770 running Network OS 6.0.2c, 7.0.1b, 7.1.0 and later
+* SLX 9850 running SLX-OS SLX-OS_16r.1.1, SLX-OS_17r.1.00 and later
+*	SLX 9540 running OS SLX-OS_17r.1.00 and later 
+*	SLX 9240 running OS SLX-OS_17s.1.00 and later
+*	SLX 9140 running OS SLX-OS_17s.1.00 and later
 
 
 .. rubric:: What's Next?

--- a/docs/source/solutions/essentials/workflows.rst
+++ b/docs/source/solutions/essentials/workflows.rst
@@ -1,13 +1,18 @@
 Network Essentials Actions
 ==========================
 
-This is a reference documentation for Network Essentials Actions and Workflows to automate Brocade VDX and SLX switches. These actions can be used as independent actions, or as part of a more complex workflow. :doc:`Actions</actions>` can be manually triggered, or they can be tied to :doc:`sensors </sensors>` using rules.
+This is a reference documentation for Network Essentials Actions and Workflows to automate VDX and
+SLX switches. These actions can be used as independent actions, or as part of a more complex
+workflow. :doc:`Actions</actions>` can be manually triggered, or they can be tied to
+:doc:`sensors </sensors>` using rules.
 
 .. contents::
    :local:
    :depth: 1
 
-Most of the actions below can be used to automate Brocade SLX or VDX switches, however there are few actions that are only valid for  VDX switches as outlined below. If an action is only valid for VDX it will be documented in the action details, otherwise the action is supported for both VDX and SLX.  
+Most of the actions below can be used to automate SLX or VDX switches, however there are some
+actions that are only valid for VDX switches as outlined below. If an action is only valid for VDX
+it will be documented in the action details, otherwise the action is supported for both VDX and SLX.  
 
 Edge Ports Configuration
 ------------------------
@@ -53,11 +58,21 @@ Edge Ports Configuration
 Virtual Fabrics
 ---------------
 
-The Virtual Fabrics (VF) feature in NOS enables Layer 2 multi-tenancy solutions that provide support for overlapping VLANs, VLAN scaling, and transparent VLAN services by providing both traditional VLAN service and a transport service.  The Virtual Fabrics feature is deployed in data centers that require logical switch partitioning with large number of customer VLAN domains that must be isolated from each other in the data plane. On the hardware platforms that support this feature, such as Brocade VDX 8770 series and Brocade VDX 6740 series, the VLAN ID range is extended from the standard 802.1Q limit of 4095, to 8191.  
+The Virtual Fabrics (VF) feature in NOS enables Layer 2 multi-tenancy solutions that provide
+support for overlapping VLANs, VLAN scaling, and transparent VLAN services by providing both
+traditional VLAN service and a transport service. The Virtual Fabrics feature is deployed in data
+centers that require logical switch partitioning with a large number of customer VLAN domains that
+must be isolated from each other in the data plane. On the hardware platforms that support this
+feature, such as VDX 8770 series and VDX 6740 series, the VLAN ID range is extended from the
+standard 802.1Q limit of 4095, to 8191.  
 
-Network Essentials v1.2 release includes new workflows and enhancements to the existing workflows to automate VF provisioning.  
+Network Essentials v1.2 release includes new workflows and enhancements to the existing workflows
+to automate VF provisioning.  
 
-A VF operates like a regular 802.1Q VLAN, but allows the number of networks to scale beyond the standard 4K (4096) limit.  Users can use  enable_vf action to enable VF on a switch. After enabling VF, users can use existing workflows to manage VFs, for example, to create or delete a VF, use create_vlan or delete_vlan actions.  
+A VF operates like a regular 802.1Q VLAN, but allows the number of networks to scale beyond the
+standard 4K (4096) limit. Users can use enable_vf action to enable VF on a switch. After enabling
+VF, users can use existing workflows to manage VFs, for example, to create or delete a VF, use
+create_vlan or delete_vlan actions.  
 
 .. include:: /_includes/solutions/essentials/enable_vf.rst
 

--- a/docs/source/solutions/overview.rst
+++ b/docs/source/solutions/overview.rst
@@ -14,24 +14,25 @@ Users may modify these workflows to customise them to their needs.
 Network Essentials
 ~~~~~~~~~~~~~~~~~~
 
-Network Essentials is a foundational set of workflows for operating Brocade network devices. It
+Network Essentials is a foundational set of workflows for operating Extreme network devices. It
 includes actions such as port provisioning, SNMP, NTP & AAA configuration. These are basic building
 blocks that are used by other suites. Customers can also use these blocks to create their own
 customised workflows.
 
-It currently supports Brocade VDX and SLX devices. See more details :doc:`here<essentials/overview>`.
+It currently supports Extreme VDX and SLX devices. See more details :doc:`here<essentials/overview>`.
 
 DC Fabric
 ~~~~~~~~~~
 
-The DC Fabric Automation Suite is an add-on package for |bwc| that provides services and pre-built automations for managing
-Brocade Data Center Fabrics - both VCS Fabric and IP Fabric architectures. It includes workflows such as:
+The DC Fabric Automation Suite is an add-on package for |bwc| that provides services and pre-built
+automations for managing Data Center Fabrics - both VCS Fabric and IP Fabric architectures. It
+includes workflows such as:
 
-* Provision and validate Brocade IP Fabrics and BGP-EVPN
+* Provision and validate IP Fabrics and BGP-EVPN
 * Perform Layer-2 path traces across VCS Fabrics
 * Find and provision edge ports
 
-It works with all current Brocade VDX switches, and SLX-9850 switches when used as a super-spine. It is currently
+It works with all current VDX switches, and SLX-9850 switches when used as a super-spine. It is currently
 available as a Technology Preview.
 
 See more details :doc:`here<dcfabric/overview>`.
@@ -43,12 +44,12 @@ The Internet Exchange suite provides workflows that target common use-cases seen
 Workflows include customer port provisioning, move systems to quarantine, MAC ACL updates, and route
 server validation.
 
-It will work with Brocade SLX-9850 and 9540 switches. Future updates will include Brocade MLXe support.
+It will work with SLX-9850 and 9540 switches. Future updates will include MLXe support.
 Technology Preview versions of this automation suite will begin shipping soon.
 
 .. rubric:: What's Next?
 
-* :doc:`Install BWC<../install/bwc>` if you haven't already!
+* :doc:`Install EWC<../install/bwc>` if you haven't already!
 * Choose which suites you need, and install them. Follow these instructions:
 
   + :doc:`Network Essentials<essentials/install>`


### PR DESCRIPTION
Begin migrating "Brocade" references to "Extreme"

This is an initial pass. There will be further work required, especially as underlying product names get changed with upcoming releases.

Related: https://github.com/StackStorm/st2docs/pull/684

Will also need PR to update theme. May leave that until Workflow Composer docs get moved from current home at bwc-docs.brocade.com