### PR TITLE
Fixed lib install for essentials

### DIFF
--- a/docs/source/solutions/essentials/install.rst
+++ b/docs/source/solutions/essentials/install.rst
@@ -18,8 +18,7 @@ On Redhat/CentOS:
 
 .. code-block:: bash
 
-  sudo yum install libxml2-dev libxslt1-dev
-  sudo yum install gcc
+  sudo yum install gcc libxml2-devel libxslt-devel
 
 Installing Network Essentials
 -----------------------------


### PR DESCRIPTION
Wrong library names used for RHEL/CentOS - it was using the Ubuntu lib names.