### PR TITLE
Use CircleCI to deploy docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ jobs:
           root: /tmp
           paths:
             - ewcdocs
+      - store_artifacts:
+          path: /tmp/ewcdocs
+          destination: ewcdocs
       - save_cache:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
+# Set EWCDOCS_BUCKET variable in CircleCI Environment
+
 version: 2
 jobs:
-  build:
+  ewcdocs:
     docker:
     - image: circleci/python:2.7
     steps:
@@ -15,7 +17,55 @@ jobs:
           name: Make EWC docs
           command: |
             BWC_BRANCH=${CIRCLE_BRANCH} make ewcdocs
+      - run:
+          name: Store HTML docs in workspace dir
+          command: mkdir /tmp/ewcdocs && cp -r docs/build/html/* /tmp/ewcdocs/
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - ewcdocs
       - save_cache:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
           paths:
             - ~/.cache/pip
+  deploy:
+    docker:
+      - image: cibuilds/aws:1.16.43
+    steps:
+      - attach_workspace:
+          at: ./generated-site
+      - run:
+          name: Deploy to ewc-docs.extremenetworks.com
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              aws s3 sync generated-site/ewcdocs/ \
+              s3://${EWCDOCS_BUCKET}/latest
+            else
+              aws s3 sync generated-site/ewcdocs/ \
+              s3://${ST2DOCS_BUCKET}/${CIRCLE_BRANCH}
+            fi
+      - run:
+          # Check the install scripts to see if this is the current GA version
+          name: Check if current GA branch, in which case also deploy to main site
+          command: |
+            GA_VER=$(curl -sSL https://stackstorm.com/packages/install.sh|grep ^BRANCH=|sed 's/[^0-9.]*//g')
+            if [ "${CIRCLE_BRANCH}" = "${GA_VER}" ]; then
+              aws s3 sync generated-site/ewcdocs/ \
+              s3://${EWCDOCS_BUCKET}/
+            else
+              echo "Not current GA version"
+            fi
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - ewcdocs
+      - deploy:
+          requires:
+            - ewcdocs
+          filters:
+            branches:
+              only:
+                - master
+                - /v[0-9]+\.[0-9]+/


### PR DESCRIPTION
Use CircleCI to save the docs built during the test process.

Simpler than current method that involves building the docs again.

Related PR https://github.com/StackStorm/st2docs/pull/849