### PR TITLE
Add nightly Circle CI build task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
 
 workflows:
   version: 2
-  build-deploy:
+  build_test_deploy_on_push:
     jobs:
       - ewcdocs
       - deploy:
@@ -76,3 +76,14 @@ workflows:
               only:
                 - master
                 - /v[0-9]+\.[0-9]+/
+  build_test_nightly:
+    jobs:
+      - ewcdocs
+    triggers:
+      - schedule:
+          # NOTE: We run it at 1 am UTC every day
+          cron: "0 1 * * *"
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
This pull request adds a nightly builder for the master branch.

Over the years we had a lot of issues related to upstream or other changes which were not directly related to changes to this repo and were only caught when we started the release process.

By having a nightly builder we will hopefully catch and be able to fix such issues earlier so they don't pile all up during the release time when build jobs are triggered.

NOTE: We could also add such builder for the version branch, but this would get complicated since it's not trivial to retrieve latest version and we can't just trigger builds for all the existing versions.