### PR TITLE
Change to Version-specific Ubuntu install doc

### DIFF
--- a/docs/source/solutions/dcfabric/install.rst
+++ b/docs/source/solutions/dcfabric/install.rst
@@ -145,7 +145,7 @@ It will walk you through installing and configuring StackStorm first, and upgrad
 to |ewc| with the license key you received when registering for evaluation or when 
 purchasing. This last step will also set up the |ewc| repository on your box.
 
-* :doc:`/install/deb`
+* :doc:`/install/u16`
 * :doc:`/install/rhel7`
 * :doc:`/install/rhel6`
 


### PR DESCRIPTION
As part of https://github.com/StackStorm/st2docs/pull/896, I'm switching to version-specific Ubuntu install docs.

This build will fail until that PR is merged, and that PR will fail builds until this one is merged.

Once *both* are merged, builds should work again